### PR TITLE
remove tap() calls.

### DIFF
--- a/src/Traits/Favoriteable.php
+++ b/src/Traits/Favoriteable.php
@@ -31,7 +31,7 @@ trait Favoriteable
                 return $this->favoriters->contains($user);
             }
 
-            return tap($this->relationLoaded('favorites') ? $this->favorites : $this->favorites())
+            return ($this->relationLoaded('favorites') ? $this->favorites : $this->favorites())
                     ->where(\config('favorite.user_foreign_key'), $user->getKey())->count() > 0;
         }
 

--- a/src/Traits/Favoriter.php
+++ b/src/Traits/Favoriter.php
@@ -55,7 +55,7 @@ trait Favoriter
      */
     public function hasFavorited(Model $object)
     {
-        return tap($this->relationLoaded('favorites') ? $this->favorites : $this->favorites())
+        return ($this->relationLoaded('favorites') ? $this->favorites : $this->favorites())
             ->where('favoriteable_id', $object->getKey())
             ->where('favoriteable_type', $object->getMorphClass())
             ->count() > 0;


### PR DESCRIPTION
reason: isFavoritedBy() and hasFavorited() always return true if relationships are eager loaded