### PR TITLE
Update migration and config

### DIFF
--- a/config/favorite.php
+++ b/config/favorite.php
@@ -19,5 +19,5 @@ return [
     /*
      * Model name for favorite record.
      */
-    'favorite_model' => 'Overtrue\LaravelFavorite\Favorite',
+    'favorite_model' => Overtrue\LaravelFavorite\Favorite::class,
 ];

--- a/migrations/2018_12_14_000000_create_favorites_table.php
+++ b/migrations/2018_12_14_000000_create_favorites_table.php
@@ -12,7 +12,7 @@ class CreateFavoritesTable extends Migration
     public function up()
     {
         Schema::create(config('favorite.favorites_table'), function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->unsignedBigInteger(config('favorite.user_foreign_key'))->index()->comment('user_id');
             $table->morphs('favoriteable');
             $table->timestamps();

--- a/migrations/2018_12_14_000000_create_favorites_table.php
+++ b/migrations/2018_12_14_000000_create_favorites_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateFavoritesTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -26,4 +26,4 @@ class CreateFavoritesTable extends Migration
     {
         Schema::dropIfExists(config('favorite.favorites_table'));
     }
-}
+};


### PR DESCRIPTION
 - Use `::class` constant instead of string in config.
 - Use `$table->id()` method instead of specific type.
 - Use anonymous class in migration.