### PR TITLE
Add support for laravel 6.x and newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     phpunit:
         strategy:
             matrix:
-                php_version: [8.0, 8.1]
+                php_version: [7.4, 8.0, 8.1]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
-        "laravel/framework": "^9.0"
+        "php": "^7.4|^8.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,9 +23,9 @@
         }
     },
     "require-dev": {
-        "mockery/mockery": "^1.4.4",
-        "phpunit/phpunit": "^9.5.10",
-        "orchestra/testbench": "^7.0",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^8.5.8|^9.5.10",
+        "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "brainmaestro/composer-git-hooks": "^2.8",
         "friendsofphp/php-cs-fixer": "^3.5"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,14 +8,14 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Application Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Application Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR. allows to install the package in `>=6.0` laravel versions.
fixes https://github.com/overtrue/laravel-favorite/issues/30