### PR TITLE
add ability to ignore migrations

### DIFF
--- a/src/FavoriteServiceProvider.php
+++ b/src/FavoriteServiceProvider.php
@@ -8,23 +8,31 @@ class FavoriteServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->publishes([
-            \dirname(__DIR__).'/config/favorite.php' => config_path('favorite.php'),
-        ], 'favorite-config');
+        if (app()->runningInConsole()) {
+            $this->registerMigrations();
 
-        $this->publishes([
-            \dirname(__DIR__).'/migrations/' => database_path('migrations'),
-        ], 'favorite-migrations');
+            $this->publishes([
+                __DIR__ . '/../migrations/' => database_path('migrations'),
+            ], 'favorite-migrations');
 
-        if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(\dirname(__DIR__).'/migrations/');
+            $this->publishes([
+                __DIR__ . '/../config/favorite.php' => config_path('favorite.php'),
+            ], 'favorite-config');
+
+        }
+    }
+
+    protected function registerMigrations()
+    {
+        if (Favorite::shouldRunMigrations()) {
+            return $this->loadMigrationsFrom(\dirname(__DIR__) . '/migrations/');
         }
     }
 
     public function register()
     {
         $this->mergeConfigFrom(
-            \dirname(__DIR__).'/config/favorite.php',
+            \dirname(__DIR__) . '/config/favorite.php',
             'favorite'
         );
     }

--- a/src/Models/Favorite.php
+++ b/src/Models/Favorite.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Overtrue\LaravelFavorite\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Overtrue\LaravelFavorite\Events\Favorited;
+use Overtrue\LaravelFavorite\Events\Unfavorited;
+
+/**
+ * @property \Illuminate\Database\Eloquent\Model $user
+ * @property \Illuminate\Database\Eloquent\Model $favoriter
+ * @property \Illuminate\Database\Eloquent\Model $favoriteable
+ */
+class Favorite extends Model
+{
+    protected $guarded = [];
+
+    protected $dispatchesEvents = [
+        'created' => Favorited::class,
+        'deleted' => Unfavorited::class,
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = \config('favorite.favorites_table');
+
+        parent::__construct($attributes);
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        self::saving(function ($favorite) {
+            $userForeignKey = \config('favorite.user_foreign_key');
+            $favorite->{$userForeignKey} = $favorite->{$userForeignKey} ?: auth()->id();
+
+            if (\config('favorite.uuids')) {
+                $favorite->{$favorite->getKeyName()} = $favorite->{$favorite->getKeyName()} ?: (string) Str::orderedUuid();
+            }
+        });
+    }
+
+    public function favoriteable(): \Illuminate\Database\Eloquent\Relations\MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(\config('auth.providers.users.model'), \config('favorite.user_foreign_key'));
+    }
+
+    public function favoriter(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->user();
+    }
+
+    public function scopeWithType(Builder $query, string $type): Builder
+    {
+        return $query->where('favoriteable_type', app($type)->getMorphClass());
+    }
+}


### PR DESCRIPTION
While i use this package with ```tenancyforlaravel``` package i need to ignore the migrations after publishing. This feature can useful for any other to


So you can now call in your AppServiceProvider.php

```php
public function register(): void{
        ...
        Favorite::ignoreMigrations();
}
```