### PR TITLE
favoriter_model added to config file

### DIFF
--- a/config/favorite.php
+++ b/config/favorite.php
@@ -20,4 +20,9 @@ return [
      * Model name for favorite record.
      */
     'favorite_model' => Overtrue\LaravelFavorite\Favorite::class,
+
+     /*
+     * Model name for favoriter model.
+     */
+    'favoriter_model' => App\Models\User::class,
 ];

--- a/src/Favorite.php
+++ b/src/Favorite.php
@@ -50,7 +50,7 @@ class Favorite extends Model
 
     public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(\config('favoriter_model'), \config('favorite.user_foreign_key'));
+        return $this->belongsTo(\config('favorite.favoriter_model'), \config('favorite.user_foreign_key'));
     }
 
     public function favoriter(): \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Favorite.php
+++ b/src/Favorite.php
@@ -50,7 +50,7 @@ class Favorite extends Model
 
     public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(\config('auth.providers.users.model'), \config('favorite.user_foreign_key'));
+        return $this->belongsTo(\config('favoriter_model'), \config('favorite.user_foreign_key'));
     }
 
     public function favoriter(): \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Traits/Favoriteable.php
+++ b/src/Traits/Favoriteable.php
@@ -25,7 +25,7 @@ trait Favoriteable
 
     public function hasBeenFavoritedBy(Model $user): bool
     {
-        if (! \is_a($user, config('favorite.favorite_model'))) {
+        if (! \is_a($user, config('favorite.favoriter_model'))) {
             return false;
         }
 
@@ -45,7 +45,7 @@ trait Favoriteable
     public function favoriters(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(
-            config('favorite.favorite_model'),
+            config('favorite.favoriter_model'),
             config('favorite.favorites_table'),
             'favoriteable_id',
             config('favorite.user_foreign_key')

--- a/src/Traits/Favoriteable.php
+++ b/src/Traits/Favoriteable.php
@@ -25,7 +25,7 @@ trait Favoriteable
 
     public function hasBeenFavoritedBy(Model $user): bool
     {
-        if (! \is_a($user, config('auth.providers.users.model'))) {
+        if (! \is_a($user, config('favorite.favorite_model'))) {
             return false;
         }
 
@@ -45,7 +45,7 @@ trait Favoriteable
     public function favoriters(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(
-            config('auth.providers.users.model'),
+            config('favorite.favorite_model'),
             config('favorite.favorites_table'),
             'favoriteable_id',
             config('favorite.user_foreign_key')

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -15,7 +15,7 @@ class FeatureTest extends TestCase
 
         Event::fake();
 
-        config(['auth.providers.users.model' => User::class]);
+        config(['favorite.favorite_model' => config('favorite.favorite_model')]);
     }
 
     public function test_basic_features()

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -15,7 +15,7 @@ class FeatureTest extends TestCase
 
         Event::fake();
 
-        config(['favorite.favorite_model' => config('favorite.favorite_model')]);
+        config(['favorite.favoriter_model' => User::class]);
     }
 
     public function test_basic_features()


### PR DESCRIPTION
add '**favoriter_model**' to favorite config instead of using '**auth.providers.users.model**' from auth config