### PR TITLE
Added PHP type hints to database migration

### DIFF
--- a/migrations/2018_12_14_000000_create_favorites_table.php
+++ b/migrations/2018_12_14_000000_create_favorites_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
         Schema::create(config('favorite.favorites_table'), function (Blueprint $table) {
             $table->id();
@@ -22,7 +22,7 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists(config('favorite.favorites_table'));
     }


### PR DESCRIPTION
This PR adds PHP type hints which were added in Laravel 10 to framework classes including migrations.