### PR TITLE
Fix PHP 8.4 Deprected parameter warning

### DIFF
--- a/src/Traits/Favoriter.php
+++ b/src/Traits/Favoriter.php
@@ -57,7 +57,7 @@ trait Favoriter
         return $this->hasMany(config('favorite.favorite_model'), config('favorite.user_foreign_key'), $this->getKeyName());
     }
 
-    public function attachFavoriteStatus(&$favoriteables, callable $resolver = null)
+    public function attachFavoriteStatus(&$favoriteables, ?callable $resolver)
     {
         $favorites = $this->favorites()->get()->keyBy(function ($item) {
             return \sprintf('%s-%s', $item->favoriteable_type, $item->favoriteable_id);


### PR DESCRIPTION
PHP Deprecated:  Overtrue\LaravelFavorite\Traits\Favoriter::attachFavoriteStatus(): Implicitly marking parameter $resolver as nullable is deprecated, the explicit nullable type must be used instead in vendor\overtrue\laravel-favorite\src\Traits\Favoriter.php on line 60